### PR TITLE
Remove default input file path

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7,9 +7,8 @@ def parse_args():
     parser.add_argument(
         "-f", "--input-file", 
         type=Path, 
-        required=False, 
-        help="Input topology.yaml file",
-        default=Path("examples/1/topology.yaml")
+        required=True,
+        help="Input topology.yaml file"
     )
     parser.add_argument(
         "-o", "--output-path",


### PR DESCRIPTION
It is confusing when this is not run within the precice-generator repository, if it searches for `examples/1/topology.yaml`. As a standalone tool, this will almost never be the desired path.